### PR TITLE
DurableProducerQueue specs

### DIFF
--- a/src/Aaron.Akka.ReliableDelivery.Tests/DurableProducerControllerSpecs.cs
+++ b/src/Aaron.Akka.ReliableDelivery.Tests/DurableProducerControllerSpecs.cs
@@ -60,5 +60,12 @@ public class DurableProducerControllerSpecs : TestKit
         await producerProbe.ExpectNoMsgAsync(100);
 
         await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 3, producerController).AsFirst());
+        await consumerControllerProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
+        producerController.Tell(new ProducerController.Request(3L, 13L, true, false));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 4, producerController));
+
+        var sendTo = (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).SendNextTo;
+        sendTo.Tell(new Job("msg-5"));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 5, producerController));
     }
 }

--- a/src/Aaron.Akka.ReliableDelivery.Tests/DurableProducerControllerSpecs.cs
+++ b/src/Aaron.Akka.ReliableDelivery.Tests/DurableProducerControllerSpecs.cs
@@ -59,6 +59,6 @@ public class DurableProducerControllerSpecs : TestKit
         // no request to producer since it has unconfirmed to begin with
         await producerProbe.ExpectNoMsgAsync(100);
 
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 3, producerController));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 3, producerController).AsFirst());
     }
 }

--- a/src/Aaron.Akka.ReliableDelivery.Tests/DurableProducerControllerSpecs.cs
+++ b/src/Aaron.Akka.ReliableDelivery.Tests/DurableProducerControllerSpecs.cs
@@ -1,0 +1,64 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="DurableProducerControllerSpecs.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Aaron.Akka.ReliableDelivery.Internal;
+using Akka.Configuration;
+using Akka.TestKit.Xunit2;
+using Akka.Util.Extensions;
+using Xunit;
+using Xunit.Abstractions;
+using static Aaron.Akka.ReliableDelivery.Tests.TestConsumer;
+using static Aaron.Akka.ReliableDelivery.DurableProducerQueue;
+using static Aaron.Akka.ReliableDelivery.Tests.TestDurableProducerQueue;
+
+namespace Aaron.Akka.ReliableDelivery.Tests;
+
+public class DurableProducerControllerSpecs : TestKit
+{
+    private static readonly Config Config = @"akka.reliable-delivery.consumer-controller.flow-control-window = 20
+     akka.reliable-delivery.consumer-controller.resend-interval-min = 1s";
+
+    public DurableProducerControllerSpecs(ITestOutputHelper output) : base(
+        Config.WithFallback(TestSerializer.Config).WithFallback(RdConfig.DefaultConfig()), output: output)
+    {
+    }
+    
+    private int _idCount = 0;
+    private int NextId() => _idCount++;
+
+    private string ProducerId => $"p-{_idCount}";
+
+    [Fact]
+    public async Task ProducerController_with_durable_queue_must_load_initial_state_resend_unconfirmed()
+    {
+        NextId();
+        var consumerControllerProbe = CreateTestProbe();
+
+        var durable = CreateProps(TimeSpan.Zero,
+            new DurableProducerQueue.State<Job>(currentSeqNr: 5, highestConfirmedSeqNr: 2,
+                confirmedSeqNr: ImmutableDictionary<string, (long, long)>.Empty.Add(NoQualifier, (2L, TestTimestamp)),
+                unconfirmed: ImmutableList<MessageSent<Job>>.Empty
+                    .Add(new MessageSent<Job>(3, new Job("msg-3"), false, NoQualifier, TestTimestamp))
+                    .Add(new MessageSent<Job>(4, new Job("msg-4"), false, NoQualifier, TestTimestamp))));
+
+        var producerController = Sys.ActorOf(ProducerController.Create<Job>(Sys, ProducerId, durable),
+            $"producerController-{_idCount}");
+        var producerProbe = CreateTestProbe();
+        producerController.Tell(new ProducerController.Start<Job>(producerProbe.Ref));
+        
+        producerController.Tell(new ProducerController.RegisterConsumer<Job>(consumerControllerProbe));
+        
+        // no request to producer since it has unconfirmed to begin with
+        await producerProbe.ExpectNoMsgAsync(100);
+
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 3, producerController));
+    }
+}

--- a/src/Aaron.Akka.ReliableDelivery.Tests/DurableProducerControllerSpecs.cs
+++ b/src/Aaron.Akka.ReliableDelivery.Tests/DurableProducerControllerSpecs.cs
@@ -12,7 +12,9 @@ using Akka.Actor;
 using Aaron.Akka.ReliableDelivery.Internal;
 using Akka.Configuration;
 using Akka.TestKit.Xunit2;
+using Akka.Util;
 using Akka.Util.Extensions;
+using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 using static Aaron.Akka.ReliableDelivery.Tests.TestConsumer;
@@ -47,7 +49,7 @@ public class DurableProducerControllerSpecs : TestKit
                 confirmedSeqNr: ImmutableDictionary<string, (long, long)>.Empty.Add(NoQualifier, (2L, TestTimestamp)),
                 unconfirmed: ImmutableList<MessageSent<Job>>.Empty
                     .Add(new MessageSent<Job>(3, new Job("msg-3"), false, NoQualifier, TestTimestamp))
-                    .Add(new MessageSent<Job>(4, new Job("msg-4"), false, NoQualifier, TestTimestamp))));
+                    .Add(new MessageSent<Job>(4, new Job("msg-4"), false, NoQualifier, TestTimestamp))), _ => false);
 
         var producerController = Sys.ActorOf(ProducerController.Create<Job>(Sys, ProducerId, durable),
             $"producerController-{_idCount}");
@@ -67,5 +69,64 @@ public class DurableProducerControllerSpecs : TestKit
         var sendTo = (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).SendNextTo;
         sendTo.Tell(new Job("msg-5"));
         await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 5, producerController));
+    }
+
+    [Fact]
+    public async Task ProducerController_with_durable_queue_must_store_confirmations()
+    {
+        NextId();
+        var consumerControllerProbe = CreateTestProbe();
+
+        var stateHolder = new AtomicReference<DurableProducerQueueStateHolder<Job>>(State<Job>.Empty);
+        var durable = CreateProps(TimeSpan.Zero,
+            stateHolder, _ => false);
+        var producerController = Sys.ActorOf(ProducerController.Create<Job>(Sys, ProducerId, durable),
+            $"producerController-{_idCount}");
+        var producerProbe = CreateTestProbe();
+        
+        producerController.Tell(new ProducerController.Start<Job>(producerProbe.Ref));
+        
+        producerController.Tell(new ProducerController.RegisterConsumer<Job>(consumerControllerProbe));
+        
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).SendNextTo.Tell(new Job("msg-1"));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 1, producerController));
+
+        await AwaitAssertAsync(() =>
+        {
+            stateHolder.Value.State.Should().Be(new State<Job>(2, 0, ImmutableDictionary<string, (long, long)>.Empty, 
+                ImmutableList.Create<MessageSent<Job>>().Add(new MessageSent<Job>(1, new Job("msg-1"), false, NoQualifier, TestTimestamp))));
+            return Task.CompletedTask;
+        });
+        
+        producerController.Tell(new ProducerController.Request(1L, 10L, true, false));
+        await AwaitAssertAsync(() =>
+        {
+            stateHolder.Value.State.Should().Be(new State<Job>(2, 1, 
+                ImmutableDictionary<string, (long, long)>.Empty
+                    .Add(NoQualifier, (1L, TestTimestamp)), 
+                ImmutableList<MessageSent<Job>>.Empty));
+            return Task.CompletedTask;
+        });
+
+        var replyTo = CreateTestProbe();
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).AskNextTo(
+            new ProducerController.MessageWithConfirmation<Job>(new Job("msg-2"), replyTo.Ref));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 2, producerController, ack:true));
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).AskNextTo(
+            new ProducerController.MessageWithConfirmation<Job>(new Job("msg-3"), replyTo.Ref));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 3, producerController, ack:true));
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).AskNextTo(
+            new ProducerController.MessageWithConfirmation<Job>(new Job("msg-4"), replyTo.Ref));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 4, producerController, ack:true));
+        producerController.Tell(new ProducerController.Ack(3L));
+        
+    await AwaitAssertAsync(() =>
+        {
+            stateHolder.Value.State.Should().Be(new State<Job>(5, 3, 
+                ImmutableDictionary<string, (long, long)>.Empty
+                    .Add(NoQualifier, (3L, TestTimestamp)), 
+                ImmutableList<MessageSent<Job>>.Empty.Add(new MessageSent<Job>(4, new Job("msg-4"), true, NoQualifier, TestTimestamp))));
+            return Task.CompletedTask;
+        });
     }
 }

--- a/src/Aaron.Akka.ReliableDelivery.Tests/DurableProducerQueueSpecs.cs
+++ b/src/Aaron.Akka.ReliableDelivery.Tests/DurableProducerQueueSpecs.cs
@@ -22,12 +22,12 @@ public class DurableProducerQueueSpecs
         var state1 = State<string>.Empty.AddMessageSent(new MessageSent<string>(1, "a", false, "", 0));
         state1.Unconfirmed.Count.Should().Be(1);
         state1.Unconfirmed.First().Message.Equals("a").Should().BeTrue();
-        state1.CurrentSeqNo.Should().Be(2);
+        state1.CurrentSeqNr.Should().Be(2);
 
         var state2 = state1.AddMessageSent(new MessageSent<string>(2, "b", false, "", 0));
         state2.Unconfirmed.Count.Should().Be(2);
         state2.Unconfirmed.Last().Message.Equals("b").Should().BeTrue();
-        state2.CurrentSeqNo.Should().Be(3);
+        state2.CurrentSeqNr.Should().Be(3);
     }
 
     [Fact]
@@ -38,7 +38,7 @@ public class DurableProducerQueueSpecs
         var state2 = state1.AddConfirmed(1L, "", 0);
         state2.Unconfirmed.Count.Should().Be(1);
         state2.Unconfirmed.First().Message.Equals("b").Should().BeTrue();
-        state2.CurrentSeqNo.Should().Be(3);
+        state2.CurrentSeqNr.Should().Be(3);
     }
 
     [Fact]
@@ -56,7 +56,7 @@ public class DurableProducerQueueSpecs
         state2.Unconfirmed.Count.Should().Be(1);
         state2.Unconfirmed.First().Message.Chunk!.Value.SerializedMessage.Should()
             .BeEquivalentTo(ByteString.FromString("a"));
-        state2.CurrentSeqNo.Should().Be(2);
+        state2.CurrentSeqNr.Should().Be(2);
 
         // replace the 2 incomplete chunks with complete ones
         var state3 = state1.AddMessageSent(MessageSent<string>.FromChunked(2,
@@ -94,6 +94,6 @@ public class DurableProducerQueueSpecs
             .BeEquivalentTo(ByteString.FromString("e"));
         state6.Unconfirmed[3].Message.Chunk!.Value.SerializedMessage.Should()
             .BeEquivalentTo(ByteString.FromString("h"));
-        state6.CurrentSeqNo.Should().Be(5);
+        state6.CurrentSeqNr.Should().Be(5);
     }
 }

--- a/src/Aaron.Akka.ReliableDelivery.Tests/TestDurableProducerQueue.cs
+++ b/src/Aaron.Akka.ReliableDelivery.Tests/TestDurableProducerQueue.cs
@@ -1,0 +1,38 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="TestDurableQueue.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using Akka.Actor;
+using Akka.Event;
+using static Aaron.Akka.ReliableDelivery.DurableProducerQueue;
+
+namespace Aaron.Akka.ReliableDelivery.Tests;
+
+/// <summary>
+/// INTERNAL API
+/// </summary>
+/// <typeparam name="T">The type of messages handled by the durable queue.</typeparam>
+public class TestDurableProducerQueue<T> : ReceiveActor
+{
+    private readonly ILoggingAdapter _log = Context.GetLogger();
+    private readonly TimeSpan _delay;
+    private readonly Predicate<IDurableProducerQueueCommand<T>> _failWhen;
+    
+    public State<T> CurrentState { get; private set; }
+
+    public TestDurableProducerQueue(TimeSpan delay, Predicate<IDurableProducerQueueCommand<T>> failWhen, State<T> initialState)
+    {
+        _delay = delay;
+        _failWhen = failWhen;
+        CurrentState = initialState;
+    }
+
+    protected override void PreStart()
+    {
+        _log.Info("Starting with seqNr [{0}], confirmedSeqNr [{1}]", CurrentState.CurrentSeqNr, CurrentState.ConfirmedSeqNr);
+    }
+}

--- a/src/Aaron.Akka.ReliableDelivery.Tests/TestDurableProducerQueue.cs
+++ b/src/Aaron.Akka.ReliableDelivery.Tests/TestDurableProducerQueue.cs
@@ -12,6 +12,20 @@ using static Aaron.Akka.ReliableDelivery.DurableProducerQueue;
 
 namespace Aaron.Akka.ReliableDelivery.Tests;
 
+public static class TestDurableProducerQueue
+{
+    /// <summary>
+    /// Used to simplify tests.
+    /// </summary>
+    public const long TestTimestamp = long.MaxValue;
+
+    public static Props CreateProps<T>(TimeSpan delay, State<T> initialState,
+        Predicate<IDurableProducerQueueCommand<T>> failWhen)
+    {
+        return Props.Create(() => new TestDurableProducerQueue<T>(delay, failWhen, initialState));
+    }
+}
+
 /// <summary>
 /// INTERNAL API
 /// </summary>
@@ -21,7 +35,7 @@ public class TestDurableProducerQueue<T> : ReceiveActor
     private readonly ILoggingAdapter _log = Context.GetLogger();
     private readonly TimeSpan _delay;
     private readonly Predicate<IDurableProducerQueueCommand<T>> _failWhen;
-    
+
     public State<T> CurrentState { get; private set; }
 
     public TestDurableProducerQueue(TimeSpan delay, Predicate<IDurableProducerQueueCommand<T>> failWhen, State<T> initialState)
@@ -29,10 +43,68 @@ public class TestDurableProducerQueue<T> : ReceiveActor
         _delay = delay;
         _failWhen = failWhen;
         CurrentState = initialState;
+        Active();
+    }
+
+    private void Active()
+    {
+        Receive<LoadState<T>>(cmd =>
+        {
+            MaybeFail(cmd);
+            if(_delay == TimeSpan.Zero)
+                cmd.ReplyTo.Tell(CurrentState);
+            else
+                Context.System.Scheduler.ScheduleTellOnce(_delay, cmd.ReplyTo, CurrentState, Self);
+        });
+
+        Receive<StoreMessageSent<T>>(cmd =>
+        {
+            if (cmd.MessageSent.SeqNr == CurrentState.CurrentSeqNr)
+            {
+                _log.Info("StoreMessageSent  seqNr {0}, confirmationQualifier [{1}]", cmd.MessageSent.SeqNr, cmd.MessageSent.ConfirmationQualifier);
+                MaybeFail(cmd);
+                var reply = new StoreMessageSentAck(cmd.MessageSent.SeqNr);
+                if(_delay == TimeSpan.Zero) 
+                    cmd.ReplyTo.Tell(reply);
+                else
+                    Context.System.Scheduler.ScheduleTellOnce(_delay, cmd.ReplyTo, reply, Self);
+                CurrentState = CurrentState.AddMessageSent(cmd.MessageSent.WithTimestamp(TestDurableProducerQueue.TestTimestamp));
+            }
+            else if (cmd.MessageSent.SeqNr == CurrentState.CurrentSeqNr - 1)
+            {
+                // already stored, could be a retry after timeout
+                _log.Info("Duplicate seqNr {0}, currentSeqNr [{1}]", cmd.MessageSent.SeqNr, CurrentState.CurrentSeqNr);
+                var reply = new StoreMessageSentAck(cmd.MessageSent.SeqNr);
+                if(_delay == TimeSpan.Zero) 
+                    cmd.ReplyTo.Tell(reply);
+                else
+                    Context.System.Scheduler.ScheduleTellOnce(_delay, cmd.ReplyTo, reply, Self);
+            }
+            else
+            {
+                // may happen after failure
+                _log.Info("Ignoring unexpected seqNr {0}, currentSeqNr [{1}]", cmd.MessageSent.SeqNr, CurrentState.CurrentSeqNr);
+                Unhandled(cmd);
+            }
+        });
+
+        Receive<StoreMessageConfirmed<T>>(cmd =>
+        {
+            _log.Info("StoreMessageConfirmed seqNr [{0}], confirmationQualifier [{1}]", cmd.SeqNr, cmd.ConfirmationQualifier);
+            MaybeFail(cmd);
+            CurrentState = CurrentState.AddConfirmed(cmd.SeqNr, cmd.ConfirmationQualifier, TestDurableProducerQueue.TestTimestamp);
+        });
+    }
+
+    private void MaybeFail(IDurableProducerQueueCommand<T> cmd)
+    {
+        if(_failWhen(cmd))
+            throw new Exception($"TestDurableProducerQueue failed at {cmd}");
     }
 
     protected override void PreStart()
     {
+        CurrentState = CurrentState.CleanUpPartialChunkedMessages();
         _log.Info("Starting with seqNr [{0}], confirmedSeqNr [{1}]", CurrentState.CurrentSeqNr, CurrentState.ConfirmedSeqNr);
     }
 }

--- a/src/Aaron.Akka.ReliableDelivery/DurableProducerQueue.cs
+++ b/src/Aaron.Akka.ReliableDelivery/DurableProducerQueue.cs
@@ -81,16 +81,16 @@ public static class DurableProducerQueue
     /// </remarks>
     public sealed class StoreMessageConfirmed<T> : IDurableProducerQueueCommand<T>
     {
-        public StoreMessageConfirmed(long seqNo, string qualifier, long timestamp)
+        public StoreMessageConfirmed(long seqNr, string confirmationQualifier, long timestamp)
         {
-            Qualifier = qualifier;
-            SeqNo = seqNo;
+            ConfirmationQualifier = confirmationQualifier;
+            SeqNr = seqNr;
             Timestamp = timestamp;
         }
 
-        public string Qualifier { get; }
+        public string ConfirmationQualifier { get; }
 
-        public long SeqNo { get; }
+        public long SeqNr { get; }
 
         public long Timestamp { get; }
     }
@@ -128,7 +128,7 @@ public static class DurableProducerQueue
 
         public State<T> AddConfirmed(long seqNr, string qualifier, long timestamp)
         {
-            var newUnconfirmed = Unconfirmed.Where(c => !(c.SeqNr <= seqNr && c.Qualifier == qualifier))
+            var newUnconfirmed = Unconfirmed.Where(c => !(c.SeqNr <= seqNr && c.ConfirmationQualifier == qualifier))
                 .ToImmutableList();
 
             return new State<T>(CurrentSeqNr, Math.Max(HighestConfirmedSeqNr, seqNr),
@@ -192,12 +192,12 @@ public static class DurableProducerQueue
     /// </summary>
     public sealed class MessageSent<T> : IDurableProducerQueueEvent, IEquatable<MessageSent<T>>
     {
-        public MessageSent(long seqNr, MessageOrChunk<T> message, bool ack, string qualifier, long timestamp)
+        public MessageSent(long seqNr, MessageOrChunk<T> message, bool ack, string confirmationQualifier, long timestamp)
         {
             SeqNr = seqNr;
             Message = message;
             Ack = ack;
-            Qualifier = qualifier;
+            ConfirmationQualifier = confirmationQualifier;
             Timestamp = timestamp;
         }
 
@@ -207,7 +207,7 @@ public static class DurableProducerQueue
 
         public bool Ack { get; }
 
-        public string Qualifier { get; }
+        public string ConfirmationQualifier { get; }
 
         public long Timestamp { get; }
 
@@ -220,7 +220,7 @@ public static class DurableProducerQueue
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
             return SeqNr == other.SeqNr && Message.Equals(other.Message) && Ack == other.Ack &&
-                   Qualifier == other.Qualifier && Timestamp == other.Timestamp;
+                   ConfirmationQualifier == other.ConfirmationQualifier && Timestamp == other.Timestamp;
         }
 
         public MessageSent<T> WithQualifier(string qualifier)
@@ -230,7 +230,7 @@ public static class DurableProducerQueue
 
         public MessageSent<T> WithTimestamp(long timestamp)
         {
-            return new MessageSent<T>(SeqNr, Message, Ack, Qualifier, timestamp);
+            return new MessageSent<T>(SeqNr, Message, Ack, ConfirmationQualifier, timestamp);
         }
 
         public override bool Equals(object? obj)
@@ -245,7 +245,7 @@ public static class DurableProducerQueue
 
         public override string ToString()
         {
-            return $"MessageSent({SeqNr}, {Message}, {Ack}, {Qualifier}, {Timestamp})";
+            return $"MessageSent({SeqNr}, {Message}, {Ack}, {ConfirmationQualifier}, {Timestamp})";
         }
 
         public static MessageSent<T> FromChunked(long seqNo, ChunkedMessage chunkedMessage, bool ack,
@@ -266,7 +266,7 @@ public static class DurableProducerQueue
             seqNo = SeqNr;
             message = Message;
             ack = Ack;
-            qualifier = Qualifier;
+            qualifier = ConfirmationQualifier;
             timestamp = Timestamp;
         }
     }

--- a/src/Aaron.Akka.ReliableDelivery/Internal/ProducerControllerImpl.cs
+++ b/src/Aaron.Akka.ReliableDelivery/Internal/ProducerControllerImpl.cs
@@ -646,8 +646,8 @@ internal sealed class ProducerController<T> : ReceiveActor, IWithTimers
             consumerController.Tell(msg);
         }
 
-        return new State(false, loadedState.CurrentSeqNo, loadedState.HighestConfirmedSeqNo, 1L, true,
-            loadedState.HighestConfirmedSeqNo + 1, unconfirmedBuilder.ToImmutable(), producer,
+        return new State(false, loadedState.CurrentSeqNr, loadedState.HighestConfirmedSeqNr, 1L, true,
+            loadedState.HighestConfirmedSeqNr + 1, unconfirmedBuilder.ToImmutable(), producer,
             ImmutableList<SequencedMessage<T>>.Empty, ImmutableDictionary<long, IActorRef>.Empty, Send, 0);
     }
 

--- a/src/Aaron.Akka.ReliableDelivery/Internal/ProducerControllerImpl.cs
+++ b/src/Aaron.Akka.ReliableDelivery/Internal/ProducerControllerImpl.cs
@@ -922,7 +922,10 @@ internal sealed class ProducerController<T> : ReceiveActor, IWithTimers
         ResendUnconfirmed(CurrentState.Unconfirmed.Where(c => c.SeqNr >= fromSeqNr).ToImmutableList());
         if (fromSeqNr == 0 && !CurrentState.Unconfirmed.IsEmpty)
         {
-            // Scala code just copies the original Unconfirmed value back into the CurrentState here.
+            // need to mark the first unconfirmed message as "first" again, so the delivery-state inside the ConsumerController is correct
+            var newUnconfirmed = ImmutableList.Create(CurrentState.Unconfirmed.First().AsFirst())
+                .AddRange(CurrentState.Unconfirmed.Skip(1));
+            CurrentState = CurrentState.WithUnconfirmed(newUnconfirmed);
         }
     }
 

--- a/src/Aaron.Akka.ReliableDelivery/Internal/ProducerControllerImpl.cs
+++ b/src/Aaron.Akka.ReliableDelivery/Internal/ProducerControllerImpl.cs
@@ -932,11 +932,11 @@ internal sealed class ProducerController<T> : ReceiveActor, IWithTimers
 
     private void StoreMessageSent(DurableProducerQueue.MessageSent<T> messageSent, int attempt)
     {
-        object Mapper(IActorRef r) => new DurableProducerQueue.StoreMessageSent<T>(messageSent, r);
+        DurableProducerQueue.StoreMessageSent<T> Mapper(IActorRef r) => new DurableProducerQueue.StoreMessageSent<T>(messageSent, r);
 
         var self = Self;
-        DurableProducerQueueRef.Value.Ask<DurableProducerQueue.StoreMessageSentAck>((Func<IActorRef, object>)Mapper,
-                Settings.DurableQueueRequestTimeout)
+        DurableProducerQueueRef.Value.Ask<DurableProducerQueue.StoreMessageSentAck>(Mapper,
+                Settings.DurableQueueRequestTimeout, cancellationToken:default)
             .PipeTo(self, success: ack => new StoreMessageSentCompleted<T>(messageSent),
                 failure: ex => new StoreMessageSentFailed<T>(messageSent, attempt));
     }

--- a/src/Aaron.Akka.ReliableDelivery/Internal/ProducerControllerImpl.cs
+++ b/src/Aaron.Akka.ReliableDelivery/Internal/ProducerControllerImpl.cs
@@ -614,10 +614,10 @@ internal sealed class ProducerController<T> : ReceiveActor, IWithTimers
         var timeout = Settings.DurableQueueRequestTimeout;
         durableProducerQueue.OnSuccess(@ref =>
         {
-            object Mapper(IActorRef r) => new DurableProducerQueue.LoadState<T>(r);
+            DurableProducerQueue.LoadState<T> Mapper(IActorRef r) => new DurableProducerQueue.LoadState<T>(r);
 
             var self = Self;
-            @ref.Ask<DurableProducerQueue.State<T>>((Func<IActorRef, object>)Mapper, timeout: timeout)
+            @ref.Ask<DurableProducerQueue.State<T>>(Mapper, timeout: timeout, cancellationToken:default)
                 .PipeTo(self, success: state => new LoadStateReply<T>(state),
                     failure: ex => new LoadStateFailed(attempt)); // timeout
         });


### PR DESCRIPTION
## Changes

`DurableProducerQueue` tests and a test implementation. The real Akka.Persistence event-sourced implementation will appear later.